### PR TITLE
타원 그리기 함수 옵션 추가

### DIFF
--- a/Grid/Framework/Debug.cs
+++ b/Grid/Framework/Debug.cs
@@ -53,6 +53,12 @@ namespace Grid.Framework
             base.Draw(sb);
             sb.Begin();
             GUI.DrawString(sb, Font, _out, Alignment.Right | Alignment.Top, (Camera.Current as Camera2D).Bounds, Color, 0);
+            /*
+            GUI.DrawPoint(sb, new Vector2(0,0), 10, Color.Coral );
+            GUI.DrawPoint(sb, new Vector2(250,400), 10, Color.Coral);
+            GUI.DrawPoint(sb, new Vector2(300, 300), 10, Color.Coral);
+            GUI.DrawEllipse(sb, new Vector2(0,0), new Vector2(250, 400), new Vector2(300,300), 1, Color.Coral, 100);
+            */
             sb.End();
         }
     }

--- a/Grid/Framework/GUI.cs
+++ b/Grid/Framework/GUI.cs
@@ -153,7 +153,13 @@ namespace Grid.Framework
             Vector2 diff = (focus1 - focus2);
             DrawVertices(sb, (focus1 + focus2) / 2, ellipseVertices(semimajor, semiminor, (float)Math.Atan2(diff.Y, diff.X), sides), border, color);
         }
-
+        public static void DrawEllipse(SpriteBatch sb, Vector2 focus1, Vector2 focus2, Vector2 pinpoint, float border, Color color, int sides)
+        {
+            float c =Vector2.Distance(focus1, focus2) / 2;
+            float semimajor = (Vector2.Distance(focus1, pinpoint) + Vector2.Distance(focus2, pinpoint)) / 2;
+            float semiminor = (float)Math.Sqrt(semimajor*semimajor - c*c);
+            DrawEllipse(sb, focus1, focus2, semimajor, semiminor, border, color, sides);
+        }
         public static void DrawPoint(SpriteBatch sb, Vector2 point, float border, Color color)
             => sb.Draw(DummyTexture, point - new Vector2(border * 0.5f), null, color, 0f, new Vector2(), Vector2.One * border, SpriteEffects.None, 0);
 


### PR DESCRIPTION
타원그리기를 초점 두개, 장축, 단축으로 그리는 함수가 있었는데 하나를 더 오버로드해서 초점 두개랑 ㅌ원상 점 하나를 인자로 받게 함. 